### PR TITLE
Pull the vulnerabilities from its own repo instead of node-security-wg

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -18,8 +18,9 @@ import (
 
 // OSSIndexURL URL for OSSIndex. Is not a hardcoded value to facilitate testing.
 const OSSIndexURL = "https://ossindex.net/api/v3/component-report"
-const nodeswgURL = "https://github.com/nodejs/security-wg/archive/master.zip"
+const nodeswgURL = "https://github.com/nodejs/security-advisories/archive/master.zip"
 
+// Advisory struct to hold description + CVE
 type Advisory struct {
 	CVE         string `json:"CVE"`
 	Description string `json:"description,omitempty"`
@@ -88,7 +89,6 @@ func stringInSlice(a string, list []Advisory) bool {
 
 // Analyze analyzes a path to an installed (npm install) node package
 func Analyze(path string, ignoreListPath string, walkers ...nodepackage.Walker) (vulnfetcher.VulnerabilityReport, error) {
-
 	if ignoreListPath != "" {
 		ignoreAdvisoriesList, err := ioutil.ReadFile(ignoreListPath)
 		if err != nil {
@@ -123,7 +123,6 @@ func Analyze(path string, ignoreListPath string, walkers ...nodepackage.Walker) 
 	if err != nil {
 		return nil, err
 	}
-
 	nodeswgFetcher := nodeswg.New(nodeswgURL)
 	err = nodeswgFetcher.Fetch()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gammaray
+module github.com/nearform/gammaray
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
@@ -7,7 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.9
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.6.2+incompatible
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0
@@ -25,7 +25,6 @@ require (
 	github.com/mgechev/dots v0.0.0-20181228164730-18fa4c4b71cc // indirect
 	github.com/mgechev/revive v0.0.0-20190124171443-202adf078678 // indirect
 	github.com/mna/pigeon v1.0.0 // indirect
-	github.com/nearform/gammaray v0.0.0-20181023151042-754a9e439d1f
 	github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443 // indirect
 	github.com/olekukonko/tablewriter v0.0.1 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,6 @@ github.com/mna/pigeon v1.0.0 h1:n46IoStjdzjaXuyBH53j9HZ8CVqGWpC7P5/v8dP4qEY=
 github.com/mna/pigeon v1.0.0/go.mod h1:Iym28+kJVnC1hfQvv5MUtI6AiFFzvQjHcvI4RFTG/04=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c h1:nXxl5PrvVm2L/wCy8dQu6DMTwH4oIuGN8GJDAlqDdVE=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/nearform/gammaray v0.0.0-20181023151042-754a9e439d1f h1:2XfXsUqoRRyMkUD8S4lJEwNL6FzqojWI3anMui3Rj14=
-github.com/nearform/gammaray v0.0.0-20181023151042-754a9e439d1f/go.mod h1:Q2XCeneUhtyb6RpIKqvV1wjiogVdqjldNupR5MQj2lY=
 github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443 h1:+2OJrU8cmOstEoh0uQvYemRGVH1O6xtO2oANUWHFnP0=
 github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443/go.mod h1:JbxfV1Iifij2yhRjXai0oFrbpxszXHRx1E5RuM26o4Y=
 github.com/olekukonko/tablewriter v0.0.0-20180912035003-be2c049b30cc/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
@@ -84,8 +82,6 @@ github.com/sdboyer/constext v0.0.0-20170321163424-836a14457353 h1:tnWWLf0nI2TI62
 github.com/sdboyer/constext v0.0.0-20170321163424-836a14457353/go.mod h1:5HStXbIikwtDAgAIqiQIqVgMn7mlvZa6PTpwiAVYGYg=
 github.com/sirupsen/logrus v1.0.6 h1:hcP1GmhGigz/O7h1WVUM5KklBp1JoNS9FggWKdj/j3s=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
-github.com/spacemeshos/go-spacemesh v0.0.0-20180219163245-f4a642e43d5b/go.mod h1:qcFGa4DJFOztEBjvEJ5a/wsgycwe1URo3I6DXHTH0qg=
-github.com/spacemeshos/go-spacemesh v0.0.0-20190221131317-c5ff0475d683 h1:X9DWEHhZJfFZ2GDZ6OFCBHtMN80yTiOpgnVn3jsvv+I=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/main.go
+++ b/main.go
@@ -86,7 +86,6 @@ func (m *Args) Run() error {
 
 // Analyze the path or docker image for vulnerabilities
 func (m *Args) Analyze() (vulnfetcher.VulnerabilityReport, error) {
-
 	var walkers []nodepackage.Walker
 	if m.OnlyPackageLock == true {
 		walkers = []nodepackage.Walker{
@@ -97,7 +96,6 @@ func (m *Args) Analyze() (vulnfetcher.VulnerabilityReport, error) {
 			yarnlockrunner.YarnLockRunner{},
 		}
 	}
-
 	if m.Image == "" && m.Path != "" {
 		return analyzer.Analyze(m.Path, m.getIgnoreList(), walkers...)
 	} else if m.Image != "" {

--- a/vulnfetcher/nodeswg/nodeswg.go
+++ b/vulnfetcher/nodeswg/nodeswg.go
@@ -42,11 +42,10 @@ func New(URL string) *Fetcher {
 func (n *Fetcher) Fetch() error {
 	tmpDir := path.Join(os.TempDir(), base64.StdEncoding.EncodeToString([]byte(n.DatabaseURL)))
 	os.Mkdir(tmpDir, os.ModePerm)
-
 	log.Info("Temporary directory for NodeSWG Database <", n.DatabaseURL, ">:\n", tmpDir)
 	destFilePath := path.Join(tmpDir, "nodeswg.zip")
 	unzipFolder := path.Join(tmpDir, "nodeswg")
-	vulnFolder := path.Join(unzipFolder, "security-wg-master", "vuln", "npm")
+	vulnFolder := path.Join(unzipFolder, "security-advisories-master", "ecosystem")
 
 	os.Mkdir(unzipFolder, os.ModePerm)
 
@@ -79,9 +78,7 @@ func (n *Fetcher) Fetch() error {
 	if err != nil {
 		return err
 	}
-
 	err = filepath.Walk(vulnFolder, func(path string, f os.FileInfo, err error) error {
-
 		if strings.HasSuffix(path, ".json") {
 			log.Debugln("Opening NodeSWG Database file <", path, ">")
 			jsonFile, err := os.Open(path)


### PR DESCRIPTION
Node.js security working group has moved the advisories into its own repo: https://github.com/nodejs/security-advisories. This PR pulls data from there instead of from node-swg repo.